### PR TITLE
Add exception (InvalidMapping)

### DIFF
--- a/include/common/Common.h
+++ b/include/common/Common.h
@@ -17,6 +17,12 @@ public:
     static std::queue<CAN_Msg> CAN_publish_q;
     static std::queue<CAN_Msg> CAN_receive_q;
 
+    class InvalidMapping : public std::exception {
+    public:
+        const char* what() const throw() {
+            return "Invalid mapping of CAN_id and MQTT_header\n";
+        }
+    };
 };
 
 #endif //CAN_MQTT_ADAPTER_COMMON_H

--- a/include/danfoss_wrapper/DanfossWrapper.h
+++ b/include/danfoss_wrapper/DanfossWrapper.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <map>
 #include <algorithm>
+#include "Common.h"
 #include "CAN_common.h"
 
 class DanfossWrapper {

--- a/src/danfoss_wrapper/DanfossWrapper.cpp
+++ b/src/danfoss_wrapper/DanfossWrapper.cpp
@@ -16,6 +16,7 @@ std::string DanfossWrapper::convertCAN2MQTT(CAN_Msg &can_msg) {
     std::string MQTT_header{CAN_id_2_MQTT_header_map_[can_msg.can_id]};
     if (MQTT_header == "") {
         std::cerr << "CAN-id to MQTT mapping not found" << std::endl;
+        throw Common::InvalidMapping();
     }
 
     // Construct MQTT payload form CAN data
@@ -42,6 +43,7 @@ CAN_Msg DanfossWrapper::convertMQTT2CAN(std::string mqtt_msg) {
 
     if (itr == end_itr) {
         std::cerr << "MQTT -> CANid mapping not found" << std::endl;
+        throw Common::InvalidMapping();
     }
 
     CAN_Msg can_msg{};


### PR DESCRIPTION
Implemented:
- throw exception (InvalidMapping) when mapping between CAN-id and MQTT are not defined.
- exception above is not catched, hence would crash the application.