### PR TITLE
Pub and sub multiple topics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,17 +20,10 @@ add_executable(CAN_MQTT_adapter
         src/danfoss_wrapper/DanfossWrapper.cpp
         )
 
-add_executable(MQTT_main
-        main.cpp
-        mqtt_main.cpp
-        src/mqtt/mqtt.cpp
-        src/common/Common.cpp
-        )
 
 find_library(PAHO_MQTT_C_LIB paho-mqtt3as)
 find_library(PAHO_MQTT_CPP_LIB paho-mqttpp3)
 find_library(THREAD_LIB pthread)
 
-target_link_libraries(MQTT_main ${PAHO_MQTT_CPP_LIB} ${PAHO_MQTT_C_LIB} ${THREAD_LIB})
 target_link_libraries(CAN_MQTT_adapter ${PAHO_MQTT_CPP_LIB} ${PAHO_MQTT_C_LIB} ${THREAD_LIB})
 

--- a/include/common/Common.h
+++ b/include/common/Common.h
@@ -8,12 +8,13 @@
 #include <queue>
 #include <string>
 #include "CAN_common.h"
+#include "mqtt_common.h"
 
 
 class Common {
 public:
-    static std::queue<std::string> MQTT_publish_q;
-    static std::queue<std::string> MQTT_receive_q;
+    static std::queue<MQTT_Msg> MQTT_publish_q;
+    static std::queue<MQTT_Msg> MQTT_receive_q;
     static std::queue<CAN_Msg> CAN_publish_q;
     static std::queue<CAN_Msg> CAN_receive_q;
 

--- a/include/danfoss_wrapper/DanfossWrapper.h
+++ b/include/danfoss_wrapper/DanfossWrapper.h
@@ -10,11 +10,12 @@
 #include <algorithm>
 #include "Common.h"
 #include "CAN_common.h"
+#include "mqtt_common.h"
 
 class DanfossWrapper {
 public:
-    static std::string convertCAN2MQTT(CAN_Msg& can_data);
-    static CAN_Msg convertMQTT2CAN(std::string mqtt_msg);
+    static MQTT_Msg convertCAN2MQTT(CAN_Msg &can_data);
+    static CAN_Msg convertMQTT2CAN(MQTT_Msg &mqtt_msg);
 
 private:
     static std::map<uint, std::string> CAN_id_2_MQTT_header_map_;

--- a/include/mqtt/mqtt.h
+++ b/include/mqtt/mqtt.h
@@ -9,23 +9,23 @@
 #include <queue>
 #include <string>
 #include "mqtt_config.h"
+#include "mqtt_common.h"
 #include "mqtt/async_client.h"
 
 
 class MQTT_ITF {
 public:
-
     MQTT_ITF(const MQTT_Config &config);
 
     bool start();
-    bool publish(std::string &message);
+    bool publish(MQTT_Msg &message);
     bool is_msg_ready() { return !msg_rx_q_.empty(); };
-    std::string next_msg();
+    MQTT_Msg next_msg();
 
 private:
     MQTT_Config config_;
     mqtt::async_client_ptr cliPtr_;
-    inline static std::queue<std::string> msg_rx_q_{};   // ask Gio why this static is needed
+    inline static std::queue<MQTT_Msg> msg_rx_q_{};   // ask Gio why this static is needed
 
     class Callback : public virtual mqtt::callback {
     public:

--- a/include/mqtt/mqtt_common.h
+++ b/include/mqtt/mqtt_common.h
@@ -1,0 +1,15 @@
+#ifndef CAN_MQTT_ADAPTER_MQTT_COMMON_H
+#define CAN_MQTT_ADAPTER_MQTT_COMMON_H
+
+#include <string>
+
+class MQTT_Msg {    
+public:
+    MQTT_Msg(std::string t, std::string p) : topic(t), payload(p) {};
+
+    std::string topic;
+    std::string payload;
+
+};
+
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -29,8 +29,7 @@ int main(int argc, char** argv) {
             Common::CAN_receive_q.pop();
 
             // Convert CAN msg to MQTT msg
-            std::string mqtt_msg{};
-            mqtt_msg = DanfossWrapper::convertCAN2MQTT(can_msg);
+            MQTT_Msg mqtt_msg = DanfossWrapper::convertCAN2MQTT(can_msg);
 
             // Push MQTT msg into MQTT_publish_q
             Common::MQTT_publish_q.push(mqtt_msg);
@@ -38,8 +37,7 @@ int main(int argc, char** argv) {
 
         if (!Common::MQTT_receive_q.empty()) {
             // Retrieve MQTT msg from MQTT_receive_q
-            std::string mqtt_msg{};
-            mqtt_msg = Common::MQTT_receive_q.front();
+            MQTT_Msg mqtt_msg = Common::MQTT_receive_q.front();
             Common::MQTT_receive_q.pop();
 
             // Convert MQTT msg to CAN msg

--- a/mqtt_main.cpp
+++ b/mqtt_main.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include "mqtt.h"
+#include "mqtt_common.h"
 #include "Common.h"
 
 using std::cout;
@@ -34,7 +35,7 @@ void MQTT_WorkerThread() {
     // Main function
     while (1) {
         if (!Common::MQTT_publish_q.empty()) {
-            std::string msg{Common::MQTT_publish_q.front()};
+            MQTT_Msg msg = Common::MQTT_publish_q.front();
             Common::MQTT_publish_q.pop();
 
             mqttCli.publish(msg);

--- a/src/common/Common.cpp
+++ b/src/common/Common.cpp
@@ -5,7 +5,7 @@
 #include "Common.h"
 
 // Initialize (static) queues
-std::queue<std::string> Common::MQTT_publish_q{};
-std::queue<std::string> Common::MQTT_receive_q{};
+std::queue<MQTT_Msg> Common::MQTT_publish_q{};
+std::queue<MQTT_Msg> Common::MQTT_receive_q{};
 std::queue<CAN_Msg> Common::CAN_publish_q{};
 std::queue<CAN_Msg> Common::CAN_receive_q{};

--- a/src/danfoss_wrapper/DanfossWrapper.cpp
+++ b/src/danfoss_wrapper/DanfossWrapper.cpp
@@ -11,36 +11,35 @@ std::map<uint, std::string> DanfossWrapper::CAN_id_2_MQTT_header_map_ = {
         {12, "Joystick_Z"}
 };
 
-std::string DanfossWrapper::convertCAN2MQTT(CAN_Msg &can_msg) {
-    // Construct MQTT header from CAN id
-    std::string MQTT_header{CAN_id_2_MQTT_header_map_[can_msg.can_id]};
-    if (MQTT_header == "") {
+MQTT_Msg DanfossWrapper::convertCAN2MQTT(CAN_Msg &can_msg) {
+    // Construct MQTT topic from CAN id
+    std::string mqtt_topic = CAN_id_2_MQTT_header_map_[can_msg.can_id];
+    if (mqtt_topic == "") {
         std::cerr << "CAN-id to MQTT mapping not found" << std::endl;
         throw Common::InvalidMapping();
     }
 
     // Construct MQTT payload form CAN data
-    uint16_t MQTT_data{};
-    ENCODE_2BYTES_TO_NUM16(can_msg.data[0], can_msg.data[1], MQTT_data);
+    uint16_t mqtt_payload_uint16{};
+    ENCODE_2BYTES_TO_NUM16(can_msg.data[0], can_msg.data[1], mqtt_payload_uint16);
 
-    std::string MQTT_msg{};
-    MQTT_msg = MQTT_header + "/" + std::to_string(MQTT_data);
-    return MQTT_msg;
+    return MQTT_Msg(mqtt_topic, std::to_string(mqtt_payload_uint16));
 }
 
-CAN_Msg DanfossWrapper::convertMQTT2CAN(std::string mqtt_msg) {
-    // Split mqtt_msg into header and data
-    std::string delimiter{"/"};
-    size_t delimiter_pos = mqtt_msg.find(delimiter);
-    std::string mqtt_header = mqtt_msg.substr(0, delimiter_pos);
-    std::string mqtt_data = mqtt_msg.substr(delimiter_pos+1, mqtt_msg.length() - (delimiter_pos+1));
-
+CAN_Msg DanfossWrapper::convertMQTT2CAN(MQTT_Msg &mqtt_msg) {
     // Construct CAN id from MQTT header
-    std::map<uint, std::string>::iterator start_itr = CAN_id_2_MQTT_header_map_.begin();
-    std::map<uint, std::string>::iterator end_itr = CAN_id_2_MQTT_header_map_.end();
-    auto itr = std::find_if(start_itr, end_itr,
-            [&mqtt_header](const std::pair<uint, std::string> &p) { return p.second == mqtt_header; });
 
+    // Check if MQTT topic is defined in the list
+    auto start_itr = CAN_id_2_MQTT_header_map_.begin();
+    auto end_itr = CAN_id_2_MQTT_header_map_.end();
+    auto itr = start_itr;
+    for ( ; itr != end_itr; itr++)
+    {
+        if (itr->second == mqtt_msg.topic)
+            break;
+    }
+
+    // Logically it should always be found, just in case
     if (itr == end_itr) {
         std::cerr << "MQTT -> CANid mapping not found" << std::endl;
         throw Common::InvalidMapping();
@@ -48,7 +47,7 @@ CAN_Msg DanfossWrapper::convertMQTT2CAN(std::string mqtt_msg) {
 
     CAN_Msg can_msg{};
     can_msg.can_id = itr->first;
-    ENCODE_NUM16_TO_2BYTES(std::stoi(mqtt_data), can_msg.data[0], can_msg.data[1]);
+    ENCODE_NUM16_TO_2BYTES(std::stoi(mqtt_msg.payload), can_msg.data[0], can_msg.data[1]);
 
     return can_msg;
 }


### PR DESCRIPTION
Previously, all topics are published and subscribed under "global".
- I.e. when we try to publish at topic "Joystick_X", with value "100", "#\Joystick_X\100" was published instead.

For now, by changing the internal MQTT_msg type, we publish above as "Joystick_X\100".