### PR TITLE
Fix -  Unable to parse signed value from CAN bus

### DIFF
--- a/src/danfoss_wrapper/DanfossWrapper.cpp
+++ b/src/danfoss_wrapper/DanfossWrapper.cpp
@@ -21,10 +21,10 @@ MQTT_Msg DanfossWrapper::convertCAN2MQTT(CAN_Msg &can_msg) {
     }
 
     // Construct MQTT payload form CAN data
-    uint16_t mqtt_payload_uint16{};
-    ENCODE_2BYTES_TO_NUM16(can_msg.data[0], can_msg.data[1], mqtt_payload_uint16);
+    int16_t mqtt_payload_int16{};
+    ENCODE_2BYTES_TO_NUM16(can_msg.data[0], can_msg.data[1], mqtt_payload_int16);
 
-    return MQTT_Msg(mqtt_topic, std::to_string(mqtt_payload_uint16));
+    return MQTT_Msg(mqtt_topic, std::to_string(mqtt_payload_int16));
 }
 
 CAN_Msg DanfossWrapper::convertMQTT2CAN(MQTT_Msg &mqtt_msg) {


### PR DESCRIPTION
Changed unsigned type (uint16_t) to signed (int16_t)